### PR TITLE
Fancy formatting that fixes the issue with dark themes on GTK/Linux

### DIFF
--- a/browserAction.html
+++ b/browserAction.html
@@ -6,16 +6,16 @@
     <title>Polyfiller</title>
     <style>
         html, body {
-            width: 505px;
+            width: 405px;
             margin: 0px;
 	    padding: 0px;
             box-sizing: border-box;
 	    color: #FFF;
-	    background-color: #44a3fc;
+	    background-color: #4e99e0;
 	    font-weight: bold;
         }
 	header {
-	    background-color: #fc55ab;
+	    background: linear-gradient(to right, #f279b9, #fce0ef);
 	    padding: 0px 5px;
 	    margin: 0px;
 	}
@@ -25,7 +25,6 @@
 	    font-weight: bold;
 	}
 	main {
-	    width: 500px;
 	    margin: 0px 5px 5px;
 	}
 

--- a/browserAction.html
+++ b/browserAction.html
@@ -10,12 +10,12 @@
             margin: 0px;
 	    padding: 0px;
             box-sizing: border-box;
-	    background-color: -moz-MenuHover;
+	    color: -moz-DialogText;
+	    background-color: -moz-Dialog;
 	    font-weight: bold;
         }
 	header {
 	    background-color: transparent;
-	    color: -moz-MenuHoverText;
 	    padding: 0px 5px;
 	    margin: 0px;
 	}
@@ -25,8 +25,6 @@
 	    font-weight: bold;
 	}
 	main {
-	    background-color: -moz-Dialog;
-	    color: -moz-DialogText;
 	    padding: 0px 5px 5px;
 	}
 

--- a/browserAction.html
+++ b/browserAction.html
@@ -6,18 +6,36 @@
     <title>Polyfiller</title>
     <style>
         html, body {
-            width: 500px;
-            margin: 5px;
+            width: 505px;
+            margin: 0px;
+	    padding: 0px;
             box-sizing: border-box;
 	    color: #FFF;
 	    background-color: #44a3fc;
 	    font-weight: bold;
         }
+	header {
+	    background-color: #fc55ab;
+	    padding: 0px 5px;
+	    margin: 0px;
+	}
+	h1 {
+	    margin: 5px 5px;
+	    padding: 0px initial;
+	    font-weight: bold;
+	}
+	main {
+	    width: 500px;
+	    margin: 0px 5px 5px;
+	}
 
     </style>
 </head>
 <body>
-<script src="browserAction.js"></script>
+  <header><h1>Polly</h1></header>
+  <main>
+    <script src="browserAction.js"></script>
+  </main>
 
 </body>
 </html>

--- a/browserAction.html
+++ b/browserAction.html
@@ -9,6 +9,9 @@
             width: 500px;
             margin: 5px;
             box-sizing: border-box;
+	    color: #FFF;
+	    background-color: #44a3fc;
+	    font-weight: bold;
         }
 
     </style>

--- a/browserAction.html
+++ b/browserAction.html
@@ -10,12 +10,12 @@
             margin: 0px;
 	    padding: 0px;
             box-sizing: border-box;
-	    color: #FFF;
-	    background-color: #4e99e0;
+	    background-color: -moz-MenuHover;
 	    font-weight: bold;
         }
 	header {
-	    background: linear-gradient(to right, #f279b9, #fce0ef);
+	    background-color: transparent;
+	    color: -moz-MenuHoverText;
 	    padding: 0px 5px;
 	    margin: 0px;
 	}
@@ -25,7 +25,9 @@
 	    font-weight: bold;
 	}
 	main {
-	    margin: 0px 5px 5px;
+	    background-color: -moz-Dialog;
+	    color: -moz-DialogText;
+	    padding: 0px 5px 5px;
 	}
 
     </style>

--- a/browserAction.js
+++ b/browserAction.js
@@ -16,7 +16,7 @@ browser.runtime.sendMessage({action: 'get'}).then((message) => {
     }
     element.appendChild(label);
     element.appendChild(input)
-    document.querySelector('body').appendChild(element);
+    document.querySelector('main').appendChild(element);
 
 
     enabledScripts = message.enabledScripts ? message.enabledScripts : [];
@@ -34,7 +34,7 @@ browser.runtime.sendMessage({action: 'get'}).then((message) => {
         }
         element.appendChild(label);
         element.appendChild(input)
-        document.querySelector('body').appendChild(element);
+        document.querySelector('main').appendChild(element);
     });
 })
 


### PR DESCRIPTION
I started making CSS edits to make Polly work well on dark themes, then started making a bunch of other edits to make it look nice. The current result is the following, which uses -moz-MenuHover for the header, and -moz-Dialog for the main body: 

https://happysmash27.me/Upload/Screenshots/Polly_themes/moz-MenuHover_moz-Dialog.png

I have also made a bunch of other themes along the way, though, and any one of theme could be preferable to the current state of the theming: 

Plain -moz-Dialog, without the hover colour: https://happysmash27.me/Upload/Screenshots/Polly_themes/moz-Dialog.png

Pink and blue, which I made to try to make the theme look equally in both dark and light themes before I realised -moz-Dialog existed: https://happysmash27.me/Upload/Screenshots/Polly_themes/PinkBlue.png. I like it because it is very unique and interesting, and think it could be good branding. 

Pink and blue but with a gradient: https://happysmash27.me/Upload/Screenshots/Polly_themes/Gradient.png. Although I like the gradient, it doesn't seem to work with the speech bubble triangle, so I do not think this theme is viable in its current state. 

A strange accident that looks surprisingly nice: https://happysmash27.me/Upload/Screenshots/Polly_themes/Accident.png

Which do you prefer? Or would something entirely different be better? 

Perhaps a theming system could be cool. 